### PR TITLE
Add authorization header to delete permission request in PendingPermi…

### DIFF
--- a/frontend/src/components/PendingPermissionCard.jsx
+++ b/frontend/src/components/PendingPermissionCard.jsx
@@ -5,7 +5,9 @@ import { toast } from 'react-hot-toast';
 const PendingPermissionCard = ({ permission, onDelete }) => {
   const handleDelete = async () => {
     try {
-      await axios.delete(`/permission/delete-permission/${permission._id}`, {
+      const token = localStorage.getItem('token');
+      await axios.delete(`/api/permission/delete-permission/${permission._id}`, {
+        headers: { Authorization: `Bearer ${token}` },
         withCredentials: true,
       });
       onDelete(permission._id);


### PR DESCRIPTION
This pull request includes an update to the `PendingPermissionCard` component to enhance security by adding authorization headers to the delete request.

Security improvement:

* [`frontend/src/components/PendingPermissionCard.jsx`](diffhunk://#diff-d4f1bb07495b28f960fcd204424e302a73292544bc719d381c0f483f782cb070L8-R10): Modified the `handleDelete` function to include an authorization header with a token retrieved from local storage when making the delete request to the `/api/permission/delete-permission/${permission._id}` endpoint.